### PR TITLE
Fixed run-on-switch

### DIFF
--- a/VDesk/VDesk.xaml.cs
+++ b/VDesk/VDesk.xaml.cs
@@ -79,7 +79,7 @@ namespace vdesk {
       for (int i = desktops.Length; i < n; i++) {
         VirtualDesktop.Create();
       }
-      return VirtualDesktop.GetDesktops().Last();
+      return VirtualDesktop.GetDesktops()[n-1];
     }
 
     private VirtualDesktop launchProcessOnDesktop(Process proc, int n) {


### PR DESCRIPTION
Run on switch now switches to and runs program in indicated desktop instead of last.
Fixed by having createmaxDesktops return the nth (or n-1th) desktop instead of last.