### PR TITLE
One-liner to hide the command prompt window when opening an application

### DIFF
--- a/VDesk/App.xaml.cs
+++ b/VDesk/App.xaml.cs
@@ -81,6 +81,7 @@ namespace VDesk {
 
 
                     ProcessStartInfo startInfo = new ProcessStartInfo(appPath, appArgs);
+                    startInfo.WindowStyle = ProcessWindowStyle.Hidden;
 
                     try {
                         if (Directory.Exists(Path.GetDirectoryName(appPath)))


### PR DESCRIPTION
If you try to open certain applications like notepad or vscode, a command prompt opens along that doesn't close by itself until you close the application that you launched, at least in my environment. This is the fix.